### PR TITLE
Add GPG Key badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
     <a href="https://zenn.dev/ryoppippi" target="_blank" alt="zenn"><img src="https://img.shields.io/badge/Zenn-%20%233EA8FF.svg?style=for-the-badge&logo=Zenn&logoColor=white"></a>
     <a href="https://www.linkedin.com/in/ryoppippi" target="_blank" alt="linkedin"><img src="https://img.shields.io/badge/linkedin-%230077B5.svg?style=for-the-badge&logo=linkedin&logoColor=white"></a>
     <a href="https://www.youtube.com/channel/UCJbUM-yZx6mESJw82-OpMuQ" target="_blank" alt="youtube"><img src="https://img.shields.io/badge/YouTube-%23FF0000.svg?style=for-the-badge&logo=YouTube&logoColor=white"></a>
+    <a href="https://github.com/ryoppippi.gpg" target="_blank" alt="GPG Key"><img src="https://gpg-badge.hesreallyhim.com/ryoppippi.svg?style=split" alt="GPG Key"></a>
 </div>
 <div align="center">
     Nostr:  npub1ry0pphdvvu96gr228ptthyhwle39n7v0hyw0zydmngac3a6x3vus2ujd30


### PR DESCRIPTION
Hi there!

I like to check out people's creative GitHub profiles. I noticed you have a GPG key on your GitHub account - nice job! That's actually pretty rare.

In order to promote and encourage GPG key usage and commit-signing on GitHub, I've built a small badge service that shows others that you have a publicly visible GPG key (in case you didn't know, GitHub automatically provides a link to users' GPG keys at github.com/USERNAME.gpg).

All this badge does is check that public link to see if there's a GPG key there - no tracking, no revenue involved, just a small way to signal that you care about promoting security on GitHub.

In case you're interested, but you don't like the look, there's also a little demo page where you can check out some other styles: https://demo.gpg-badge.hesreallyhim.com/

If you're not interested, feel free to close the PR - no hard feelings! Just trying to spread awareness about security and keys on GitHub. I hope this PR is not a nuisance, and thanks either way for contributing to a positive security culture on GitHub.